### PR TITLE
Disable auto update of launcher

### DIFF
--- a/cddagl/ui/views/settings.py
+++ b/cddagl/ui/views/settings.py
@@ -123,17 +123,17 @@ class LauncherSettingsGroupBox(QGroupBox):
         layout.addWidget(allow_mul_insts_checkbox, 3, 0, 1, 2)
         self.allow_mul_insts_checkbox = allow_mul_insts_checkbox
 
-        no_launcher_version_check_checkbox = QCheckBox()
-        check_state = (Qt.Checked if config_true(get_config_value(
-            'prevent_version_check_launch', 'False'))
-            else Qt.Unchecked)
-        no_launcher_version_check_checkbox.setCheckState(
-            check_state)
-        no_launcher_version_check_checkbox.stateChanged.connect(
-            self.nlvcc_changed)
-        layout.addWidget(no_launcher_version_check_checkbox, 4, 0, 1, 2)
-        self.no_launcher_version_check_checkbox = (
-            no_launcher_version_check_checkbox)
+        #no_launcher_version_check_checkbox = QCheckBox()
+        #check_state = (Qt.Checked if config_true(get_config_value(
+        #    'prevent_version_check_launch', 'False'))
+        #    else Qt.Unchecked)
+        #no_launcher_version_check_checkbox.setCheckState(
+        #    check_state)
+        #no_launcher_version_check_checkbox.stateChanged.connect(
+        #    self.nlvcc_changed)
+        #layout.addWidget(no_launcher_version_check_checkbox, 4, 0, 1, 2)
+        #self.no_launcher_version_check_checkbox = (
+        #    no_launcher_version_check_checkbox)
 
         self.setLayout(layout)
         self.set_text()
@@ -152,8 +152,8 @@ class LauncherSettingsGroupBox(QGroupBox):
                 locale=get_ui_locale()))
         self.allow_mul_insts_checkbox.setText(_('Allow multiple instances of '
             'the launcher to be started'))
-        self.no_launcher_version_check_checkbox.setText(_('Do not check '
-            'for new version of the CDDA Game Launcher on launch'))
+        #self.no_launcher_version_check_checkbox.setText(_('Do not check '
+        #    'for new version of the CDDA Game Launcher on launch'))
         self.setTitle(_('Launcher'))
 
     @property

--- a/cddagl/ui/views/tabbed.py
+++ b/cddagl/ui/views/tabbed.py
@@ -71,7 +71,7 @@ class TabbedWindow(QMainWindow):
         self.help_menu.setTitle(_('&Help'))
         self.faq_action.setText(_('&Frequently asked questions (FAQ)'))
         self.game_issue_action.setText(_('&Game issue'))
-        self.update_action.setText(_('&Check for update'))
+        #self.update_action.setText(_('&Check for update'))
         self.about_action.setText(_('&About CDDA Game Launcher'))
 
         if self.about_dialog is not None:
@@ -116,10 +116,10 @@ class TabbedWindow(QMainWindow):
 
         self.help_menu.addSeparator()
 
-        update_action = QAction(_('&Check for update'), self,
-            triggered=self.manual_update_check)
-        self.update_action = update_action
-        self.help_menu.addAction(update_action)
+        #update_action = QAction(_('&Check for update'), self,
+        #    triggered=self.manual_update_check)
+        #self.update_action = update_action
+        #self.help_menu.addAction(update_action)
 
         about_action = QAction(_('&About CDDA Game Launcher'), self,
             triggered=self.show_about_dialog)
@@ -266,7 +266,7 @@ class TabbedWindow(QMainWindow):
             no_launcher_version_check_checkbox.setText(_('Do not check '
                 'for new version of the CDDA Game Launcher on launch'))
             check_state = (Qt.Checked if config_true(get_config_value(
-                'prevent_version_check_launch', 'False'))
+                'prevent_version_check_launch', 'True'))
                 else Qt.Unchecked)
             no_launcher_version_check_checkbox.stateChanged.connect(
                 self.nlvcc_changed)
@@ -308,7 +308,7 @@ class TabbedWindow(QMainWindow):
 
     def manual_update_check(self):
         self.in_manual_update_check = True
-        self.check_new_launcher_version()
+        #self.check_new_launcher_version()
 
     def no_launcher_update_found(self):
         if self.in_manual_update_check:
@@ -369,7 +369,7 @@ class TabbedWindow(QMainWindow):
             if not config_true(get_config_value('prevent_version_check_launch',
                 'False')):
                 self.in_manual_update_check = False
-                self.check_new_launcher_version()
+               # self.check_new_launcher_version()
 
         self.shown = True
 


### PR DESCRIPTION
Turn off auto update as it would still point to the original launcher and that's a headache to figure out