### PR TITLE
Fix "Build unavailable" for latest builds

### DIFF
--- a/cddagl/constants.py
+++ b/cddagl/constants.py
@@ -26,7 +26,7 @@ CDDAGL_ISSUE_URL_ROOT = 'https://github.com/remyroy/CDDA-Game-Launcher/issues/'
 GAME_ISSUE_URL = 'https://cataclysmdda.org/#ive-found-a-bug--i-would-like-to-make-a-suggestion-what-should-i-do'
 
 BUILD_TAG = lambda bn: f'cdda-jenkins-b{bn}'
-NEW_BUILD_TAG = lambda bn: f'experimental-{bn}'
+NEW_BUILD_TAG = lambda bn: f'cdda-experimental-{bn}'
 
 WORLD_FILES = set(('worldoptions.json', 'worldoptions.txt', 'master.gsav'))
 

--- a/cddagl/ui/views/main.py
+++ b/cddagl/ui/views/main.py
@@ -1444,7 +1444,7 @@ class UpdateGroupBox(QGroupBox):
         new_target_regex = re.compile(
             r'cdda-windows-' +
             re.escape(new_asset_graphics) + r'-' +
-            re.escape(new_asset_platform) + r'-' +
+            re.escape(new_asset_platform) + r'-msvc-' +
             r'b?(?P<build>[0-9\-]+)\.zip'
             )
 
@@ -2911,7 +2911,7 @@ class UpdateGroupBox(QGroupBox):
         new_target_regex = re.compile(
             r'cdda-windows-' +
             re.escape(new_asset_graphics) + r'-' +
-            re.escape(new_asset_platform) + r'-' +
+            re.escape(new_asset_platform) + r'-msvc-' +
             r'b?(?P<build>[0-9\-]+)\.zip'
             )
 


### PR DESCRIPTION
Apply fix suggested in https://github.com/remyroy/CDDA-Game-Launcher/issues/634
And add missing `-msvc-` in the name of the files the launcher was trying to download