### PR TITLE
Fix several issues with sessions and moving files during updates

### DIFF
--- a/cddagl/ui/views/backups.py
+++ b/cddagl/ui/views/backups.py
@@ -1103,7 +1103,7 @@ class BackupsTab(QTabWidget):
     def get_save_dir(self):
         save_dir = os.path.join(self.game_dir, 'save')
         session = get_config_value('session_directory')
-        if session != 'default_session' and session is not None:
+        if session != self.game_dir and session is not None:
             save_dir = os.path.join(session, 'save')
             if not os.path.isdir(save_dir) and os.path.isdir(session):
                 try:
@@ -1146,7 +1146,7 @@ class BackupsTab(QTabWidget):
     def get_backup_dir(self):
         backup_dir = os.path.join(self.game_dir, 'save_backups')
         session = get_config_value('session_directory')
-        if session != 'default_session' and session is not None:
+        if session != self.game_dir and session is not None:
             backup_dir = os.path.join(session, 'save_backups')
             if not os.path.isdir(backup_dir) and os.path.isdir(session):
                 try:
@@ -1197,6 +1197,7 @@ class BackupsTab(QTabWidget):
 
         self.backups_scan = scandir(backup_dir)
         save_dir_name = get_config_value('session_directory')
+        # Check default_session for compatibility with 1.6.3
         if save_dir_name == 'default_session' or save_dir_name is None:
             save_dir_name = 'save/'
         else:
@@ -1218,7 +1219,7 @@ class BackupsTab(QTabWidget):
                                 uncompressed_size += info.file_size
 
                                 path_items = info.filename.split('/')
-                                target_length = 3 if get_config_value('session_directory') =='default_session' else 4
+                                target_length = 3 if get_config_value('session_directory') == self.game_dir else 4
                                 if len(path_items) == target_length:
                                     save_file = path_items[-1]
                                     if save_file.endswith('.sav'):

--- a/cddagl/ui/views/main.py
+++ b/cddagl/ui/views/main.py
@@ -2300,10 +2300,6 @@ class UpdateGroupBox(QGroupBox):
             if os.path.dirname(session) == game_dir:
                 excluded_dirs.append( os.path.basename(os.path.normpath(session)))
 
-        for entry in dir_list:
-            if entry not in excluded_dirs:
-                self.backup_dir_list.append(entry)
-
         if (config_true(get_config_value('prevent_save_move', 'False'))
             and 'save' in dir_list):
             dir_list.remove('save')
@@ -2314,6 +2310,10 @@ class UpdateGroupBox(QGroupBox):
             launcher_name = os.path.basename(launcher_exe)
             if launcher_name in dir_list:
                 dir_list.remove(launcher_name)
+
+        for entry in dir_list:
+            if entry not in excluded_dirs:
+                self.backup_dir_list.append(entry)
 
         if len(dir_list) > 0:
             status_bar.showMessage(_('Backing up current game'))

--- a/cddagl/ui/views/main.py
+++ b/cddagl/ui/views/main.py
@@ -247,7 +247,7 @@ class GameDirGroupBox(QGroupBox):
 
     def set_text(self):
         self.dir_label.setText(_('Directory:'))
-        self.session_label.setText(_('Session:'))
+        self.session_label.setText(_('User Data:'))
         self.version_label.setText(_('Version:'))
         self.build_label.setText(_('Build:'))
         self.saves_label.setText(_('Saves:'))
@@ -2298,7 +2298,7 @@ class UpdateGroupBox(QGroupBox):
         excluded_dirs = []
         for session in sessions:
             if os.path.dirname(session) == game_dir:
-                excluded_dirs.append( os.path.basename(os.path.normpath(session)))
+                excluded_dirs.append(os.path.basename(os.path.normpath(session)))
 
         if (config_true(get_config_value('prevent_save_move', 'False'))
             and 'save' in dir_list):

--- a/cddagl/ui/views/main.py
+++ b/cddagl/ui/views/main.py
@@ -246,7 +246,7 @@ class GameDirGroupBox(QGroupBox):
         self.set_text()
 
     def set_text(self):
-        self.dir_label.setText(_('Directory:'))
+        self.dir_label.setText(_('Game Directory:'))
         self.session_label.setText(_('User Data:'))
         self.version_label.setText(_('Version:'))
         self.build_label.setText(_('Build:'))

--- a/cddagl/ui/views/main.py
+++ b/cddagl/ui/views/main.py
@@ -2527,12 +2527,12 @@ class UpdateGroupBox(QGroupBox):
                         values = json.load(f)
                         if isinstance(values, dict):
                             if values.get('type', '') == 'MOD_INFO':
-                                return values.get('ident', None)
+                                return values.get('id', None)
                         elif isinstance(values, list):
                             for item in values:
                                 if (isinstance(item, dict)
                                     and item.get('type', '') == 'MOD_INFO'):
-                                        return item.get('ident', None)
+                                        return item.get('id', None)
                     except ValueError:
                         pass
             except FileNotFoundError:

--- a/cddagl/ui/views/main.py
+++ b/cddagl/ui/views/main.py
@@ -293,8 +293,9 @@ class GameDirGroupBox(QGroupBox):
             self.game_directory_changed()
 
             sess_directory = get_config_value('session_directory')
-            if sess_directory is None or sess_directory == game_directory:
-                sess_directory = 'default_session'
+            # Check for default_session for compatibility with 1.6.3
+            if sess_directory == 'default_session' or sess_directory is None:
+                sess_directory = game_directory
             self.set_sess_combo_value(sess_directory)
             self.sess_directory_changed()
 
@@ -465,7 +466,7 @@ class GameDirGroupBox(QGroupBox):
             params = ' ' + params
 
         current_session = get_config_value('session_directory')
-        if current_session != 'default_session' and current_session is not None:
+        if current_session != self.game_dir and current_session is not None:
             self.get_main_window().statusBar().showMessage(current_session)
             params = params + ' ' + '--userdir' + ' ' + '\"' + current_session + '/\"'
 
@@ -652,11 +653,6 @@ antivirus whitelist or select the action to trust this binary when detected.</p>
 
     def sess_directory_changed(self):
         directory = self.sess_combo.currentText()
-        game_dir = self.dir_combo.currentText()
-        if directory == game_dir:
-            directory = 'default_session'
-            self.sess_combo.setCurrentText(directory)
-            self.sess_directory_changed()
 
         set_config_value('session_directory', directory)
         self.add_session_dir()
@@ -694,8 +690,8 @@ antivirus whitelist or select the action to trust this binary when detected.</p>
     def game_directory_changed(self):
         directory = self.dir_combo.currentText()
         sess_dir = self.sess_combo.currentText()
-        if directory == sess_dir:
-            self.sess_combo.setCurrentText('default_session')
+        if not os.path.isdir(sess_dir):
+            self.sess_combo.setCurrentText(directory)
             self.sess_directory_changed()
 
         main_window = self.get_main_window()
@@ -1038,7 +1034,7 @@ antivirus whitelist or select the action to trust this binary when detected.</p>
             self.saves_value_edit.setText(_('Unknown'))
 
         save_dir = os.path.join(self.game_dir, 'save')
-        if session != 'default_session' and session is not None:
+        if session != self.game_dir and session is not None:
             save_dir = os.path.join(session, 'save')
 
         if not os.path.isdir(save_dir):

--- a/cddagl/ui/views/soundpacks.py
+++ b/cddagl/ui/views/soundpacks.py
@@ -1139,7 +1139,7 @@ class SoundpacksTab(QTabWidget):
 
         session = get_config_value('session_directory')
         soundpacks_dir = os.path.join(new_dir, 'data', 'sound')
-        if session != 'default_session' and session is not None:
+        if session != self.game_dir and session is not None:
             soundpacks_dir = os.path.join(session, 'sound')
             if not os.path.isdir(soundpacks_dir) and os.path.isdir(session):
                 try:


### PR DESCRIPTION
- [x] Rename `Session` to `User data` and `Directory` to `Game Directory`
- [x] Get rid of `default_session` special case
- [x] Fix #39 
- [x] Don't move the launcher.exe during update if it's in the game directory
- [x] Fix #31 