### PR TITLE
Fix crash on some changelog entry

### DIFF
--- a/cddagl/ui/views/main.py
+++ b/cddagl/ui/views/main.py
@@ -3438,12 +3438,13 @@ class UpdateGroupBox(QGroupBox):
                 )
                 changelog_html.write('<ul>')
                 body = sorted_entry.body
-                if len(body)>2:
+                msg = ''
+                if len(body) > 2:
                     if body[0].rstrip() == '':
                         msg = body[2]
-                    elif len(body)>3:
+                    elif len(body) > 3:
                         msg = body[3]
-                    msg=msg[18:]
+                    msg = msg[18:]
                 else:
                     msg = sorted_entry.title
 


### PR DESCRIPTION
Fixes #47 
Fixes #48 
Fixes #49 
Fixes #50 
Fixes #51 
Fixes #52 
Fixes #53 
Fixes #54 

Well Bug reports are working at least... X)

This should fix the crash were a changelog entry would be just the right length to crash the launcher.