### PR TITLE
Fix bug where backup would not show the right number of world and characters

### DIFF
--- a/cddagl/ui/views/backups.py
+++ b/cddagl/ui/views/backups.py
@@ -1248,7 +1248,7 @@ class BackupsTab(QTabWidget):
                                     session = self.game_dir
 
                                 path_items = info.filename.split('/')
-                                target_length = 3 if session == self.game_dir else 4
+                                target_length = 3
 
                                 if len(path_items) == target_length:
                                     save_file = path_items[-1]


### PR DESCRIPTION
If `Game_Directory` and `User_data` were not set to the same directory the backups would show as containing 0 character and 0 world

This fixes the issue