### PR TITLE
Be smarter about deleting the old launcher

### DIFF
--- a/cddagl/ui/views/tabbed.py
+++ b/cddagl/ui/views/tabbed.py
@@ -576,7 +576,7 @@ class LauncherUpdateDialog(QDialog):
 
                 current_dir = Path(exe_path).parent
                 old_exe_dir = Path(current_dir / 'old_launcher')
-                Path(old_exe_dir / 'Launcher.exe').unlink(missing_ok=True)
+                Path(old_exe_dir / Path(exe_path).name).unlink(missing_ok=True)
                 Path(old_exe_dir).mkdir(parents=True, exist_ok=True)
 
                 move(exe_path, old_exe_dir)


### PR DESCRIPTION
Fix #59 

Instead of only deleting `old_launcher\Launcher.exe` (which was already a bit dumb since the launcher is called `launcher.exe`) actually delete the file where we want to move the current launcher, that way we're sure it's going to be fine even if the user has renamed it to something else