### PR TITLE
Don't ask user to select build type, grab them all

### DIFF
--- a/cddagl/ui/views/main.py
+++ b/cddagl/ui/views/main.py
@@ -3076,11 +3076,13 @@ class UpdateGroupBox(QGroupBox):
         if selected_branch == self.experimental_radio_button:
             self.find_build_warning_label.show()
 
-    def switch_build_type(self):
+    def build_type_unavailable(self):
         if self.msvc_radio_button.isChecked():
-           self.build_type_clicked(self.msvc_radio_button)
-        elif self.other_radio_button.isChecked():
+            self.other_radio_button.setChecked(True)
             self.build_type_clicked(self.other_radio_button)
+        elif self.other_radio_button.isChecked():
+            self.msvc_radio_button.setChecked(True)
+            self.build_type_clicked(self.msvc_radio_button)
 
     def lb_http_finished(self):
         main_window = self.get_main_window()
@@ -3240,24 +3242,23 @@ class UpdateGroupBox(QGroupBox):
 
             combo_model = self.builds_combo.model()
             default_set = False
-            unavailabe_count = 0
             for x in range(combo_model.rowCount()):
                 if combo_model.item(x).data(Qt.UserRole)['url'] is None:
                     combo_model.item(x).setEnabled(False)
                     combo_model.item(x).setText(combo_model.item(x).text() +
                         _(' - build unavailable'))
-                    unavailabe_count += 1
                 elif not default_set:
                     default_set = True
                     self.builds_combo.setCurrentIndex(x)
                     combo_model.item(x).setText(combo_model.item(x).text() +
                         _(' - latest build available'))
-            if unavailabe_count == combo_model.rowCount():
-                if self.tried_build_types_count < 2:
-                    self.switch_build_type()
+            if not default_set:
+                if self.tried_build_types_count < 1:
                     self.tried_build_types_count += 1
+                    self.build_type_unavailable()
                 else:
                     self.update_button.setEnabled(False)
+                    self.update_button.setText(_('No builds available currently'))
 
             if not game_dir_group_box.game_started:
                 self.builds_combo.setEnabled(True)

--- a/cddagl/ui/views/main.py
+++ b/cddagl/ui/views/main.py
@@ -1433,6 +1433,7 @@ class UpdateGroupBox(QGroupBox):
         update_button.clicked.connect(self.update_game)
         layout.addWidget(update_button, layout_row, 0, 1, 5)
         self.update_button = update_button
+        self.tried_build_types_count = 0
 
         layout.setColumnStretch(1, 100)
         layout.setColumnStretch(2, 100)
@@ -3075,6 +3076,12 @@ class UpdateGroupBox(QGroupBox):
         if selected_branch == self.experimental_radio_button:
             self.find_build_warning_label.show()
 
+    def switch_build_type(self):
+        if self.msvc_radio_button.isChecked():
+           self.build_type_clicked(self.msvc_radio_button)
+        elif self.other_radio_button.isChecked():
+            self.build_type_clicked(self.other_radio_button)
+
     def lb_http_finished(self):
         main_window = self.get_main_window()
 
@@ -3233,16 +3240,24 @@ class UpdateGroupBox(QGroupBox):
 
             combo_model = self.builds_combo.model()
             default_set = False
+            unavailabe_count = 0
             for x in range(combo_model.rowCount()):
                 if combo_model.item(x).data(Qt.UserRole)['url'] is None:
                     combo_model.item(x).setEnabled(False)
                     combo_model.item(x).setText(combo_model.item(x).text() +
                         _(' - build unavailable'))
+                    unavailabe_count += 1
                 elif not default_set:
                     default_set = True
                     self.builds_combo.setCurrentIndex(x)
                     combo_model.item(x).setText(combo_model.item(x).text() +
                         _(' - latest build available'))
+            if unavailabe_count == combo_model.rowCount():
+                if self.tried_build_types_count < 2:
+                    self.switch_build_type()
+                    self.tried_build_types_count += 1
+                else:
+                    self.update_button.setEnabled(False)
 
             if not game_dir_group_box.game_started:
                 self.builds_combo.setEnabled(True)


### PR DESCRIPTION
Fixes #67 
When one of the build type is unavailable the launcher doesn't communicate clearly what's going on and user might fail to switch build type to fix the issue

Fixes #68 
When all build of one types are unavailable the launcher will let you try to get one anyway which leads to an un unclear error

This Pr aims to fix both error by having ~~the launcher automatically switch to the other build type if enough builds are unavailable~~
Actually we never needed to let user select the build type in the first place, let's just get rid of the option and grab all the available builds. This should solve the issue by always showing the available builds (msvc or other) if they exists. 

If all builds fail for both other and msvc for a 100 build happens in the future we can revisit this and add something to tell players it's not the launcher's fault
