### PR TITLE
Add version to save backup before update

### DIFF
--- a/cddagl/ui/views/main.py
+++ b/cddagl/ui/views/main.py
@@ -1719,9 +1719,9 @@ class UpdateGroupBox(QGroupBox):
                 backups_tab = main_tab.get_backups_tab()
 
                 backups_tab.prune_auto_backups()
-
-                name = '{auto}_{name}'.format(auto=_('auto'),
-                    name=_('before_update'))
+                current_build = main_tab.game_dir_group_box.current_build
+                name = '{auto}_{name}_{build}v'.format(auto=_('auto'),
+                    name=_('before_update'), build=current_build)
 
                 backups_tab.after_backup = self.update_game_process
                 backups_tab.backup_saves(name)


### PR DESCRIPTION
Fixes #71

Auto save backup will now be named `auto_before_update_<version>v`

![image](https://github.com/Fris0uman/CDDA-Game-Launcher/assets/41293484/a822112d-0618-48ee-952f-177045ff9039)
