### PR TITLE
Get the real stable on top of the candidates

### DIFF
--- a/cddagl/ui/views/main.py
+++ b/cddagl/ui/views/main.py
@@ -3268,7 +3268,10 @@ class UpdateGroupBox(QGroupBox):
                     stable_name += ' release candidate'
                     tmp_changelog += f'<h3>{stable_name}</h3> <p><a href="https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt">Changelog</a></p>'
                 else:
-                    tmp_changelog += f'<h3>{stable_name} {release["name"]}</h3>' + '<p>' + release['body'] + '</p>'
+                    tmp_changelog += f'<h3>{stable_name} {release["name"]}</h3> ' \
+                                     f'<p><a href="https://github.com/CleverRaven/Cataclysm-DDA/blob/master' \
+                                     f'/data/changelog.txt">Changelog</a></p>' \
+                                     + '<p>' + release['body'].replace("\n", "<br />\n") + '</p>'
 
                 stable_assets = list(filter(lambda d: build_regex.match(d['name']), release['assets']))
                 # We simply get the first valid build


### PR DESCRIPTION
0.H just came out and current infrastructure of the launcher doesn't catch its tag, this solve this issue and tries to get it ready to work for future releases too

Also adds the blurb form the release itself in the launcher

![image](https://github.com/user-attachments/assets/e4f3319f-5658-46a0-bfcb-8ec4507028e5)


