### PR TITLE
Check tags_data before working on it to avoid crashes

### DIFF
--- a/cddagl/ui/views/main.py
+++ b/cddagl/ui/views/main.py
@@ -3218,6 +3218,21 @@ class UpdateGroupBox(QGroupBox):
             logger.warning(msg)
             return []  # We failed to get the tags we can stop here
 
+        # Validate tags_data
+        if not isinstance(tags_data, list):  # Is it a list
+            msg = f'Failed to retrieve stable tags, tags_data is not a list.'
+            if status_bar.busy == 0:
+                status_bar.showMessage(msg)
+            logger.warning(msg)
+            return []
+        for item in tags_data:
+            if not isinstance(item, dict):  # Is it a list of dict
+                msg = f'Failed to retrieve stable tags, tags_data is not a list of dictionary.'
+                if status_bar.busy == 0:
+                    status_bar.showMessage(msg)
+                logger.warning(msg)
+                return []
+
         stable_refs = list(filter(lambda d: tag_regex.match(d['ref']), tags_data))
         stable_tags = []
         stable_letter = ""

--- a/cddagl/ui/views/main.py
+++ b/cddagl/ui/views/main.py
@@ -3219,8 +3219,8 @@ class UpdateGroupBox(QGroupBox):
             return []  # We failed to get the tags we can stop here
 
         # Validate tags_data
-        if not isinstance(tags_data, list):  # Is it a list
-            msg = f'Failed to retrieve stable tags, tags_data is not a list.'
+        if not isinstance(tags_data, list) or not tags_data:  # Is it a list
+            msg = f'Failed to retrieve stable tags, tags_data is not a list or is empty.'
             if status_bar.busy == 0:
                 status_bar.showMessage(msg)
             logger.warning(msg)


### PR DESCRIPTION
Fix #97 

I can't reproduce it but there must be situations where tags_data is not a list of dictionnary as expected in the rest of the code which causes a crash. 
I'm adding two checks to make sure tags_data is what we expect it to be