### PR TITLE
Fixes inconsistent crashes post Pyside6 migration

### DIFF
--- a/cddagl/constants.py
+++ b/cddagl/constants.py
@@ -633,6 +633,3 @@ def get_locale_path(*subpaths):
 def get_data_path(*subpaths):
     return os.path.join(get_cddagl_path(), 'data', *subpaths)
 
-def get_cdda_uld_path(*subpaths):
-    """Returns path used for CDDA when 'Use the launcher directory as game directory' is set."""
-    return os.path.join(get_cddagl_path(), 'cdda', *subpaths)

--- a/cddagl/ui/views/backups.py
+++ b/cddagl/ui/views/backups.py
@@ -10,11 +10,9 @@ from os import scandir
 
 import arrow
 from PySide6.QtCore import Qt, QTimer, Signal, QThread, QItemSelectionModel, QItemSelection
-from PySide6.QtWidgets import (
-    QApplication, QWidget, QGridLayout, QGroupBox, QLabel, QLineEdit, QPushButton,
-    QProgressBar, QTabWidget, QCheckBox, QMessageBox, QStyle, QHBoxLayout, QSpinBox,
-    QAbstractItemView, QSizePolicy, QTableWidget, QTableWidgetItem
-)
+from PySide6.QtWidgets import (QApplication, QWidget, QGridLayout, QGroupBox, QLabel, QLineEdit, QPushButton,
+                               QProgressBar, QTabWidget, QCheckBox, QMessageBox, QStyle, QHBoxLayout, QSpinBox,
+                               QAbstractItemView, QSizePolicy, QTableWidget, QTableWidgetItem)
 from babel.dates import format_datetime
 from babel.numbers import format_percent
 
@@ -42,8 +40,8 @@ class BackupsTab(QTabWidget):
         self.backup_compressing = False
 
         self.compressing_timer = None
-        self.scale_factor = 0 # Number of bits to shift file size right so we don't overflow the QProgressBar
-        self.filestep = 0 # File counter so we don't update the progress bar every single file
+        self.scale_factor = 0  # Number of bits to shift file size right so we don't overflow the QProgressBar
+        self.filestep = 0  # File counter so we don't update the progress bar every single file
 
         current_backups_gb = QGroupBox()
         self.current_backups_gb = current_backups_gb
@@ -54,13 +52,11 @@ class BackupsTab(QTabWidget):
 
         backups_table = QTableWidget()
         backups_table.setColumnCount(8)
-        backups_table.setSelectionBehavior(QAbstractItemView.SelectRows)
-        backups_table.setSelectionMode(QAbstractItemView.SingleSelection)
+        backups_table.setSelectionBehavior(QAbstractItemView.SelectionBehavior.SelectRows)
+        backups_table.setSelectionMode(QAbstractItemView.SelectionMode.SingleSelection)
         backups_table.verticalHeader().setVisible(False)
-        backups_table.horizontalHeader().sortIndicatorChanged.connect(
-            self.backups_table_header_sort)
-        backups_table.itemSelectionChanged.connect(
-            self.backups_table_selection_changed)
+        backups_table.horizontalHeader().sortIndicatorChanged.connect(self.backups_table_header_sort)
+        backups_table.itemSelectionChanged.connect(self.backups_table_selection_changed)
         current_backups_gb_layout.addWidget(backups_table, 0, 0, 1, 3)
         self.backups_table = backups_table
 
@@ -91,12 +87,11 @@ class BackupsTab(QTabWidget):
         self.delete_button = delete_button
 
         do_not_backup_previous_cb = QCheckBox()
-        check_state = (Qt.CheckState.Checked if config_true(get_config_value(
-            'do_not_backup_previous', 'False')) else Qt.CheckState.Unchecked)
+        check_state = (Qt.CheckState.Checked if config_true(
+            get_config_value('do_not_backup_previous', 'False')) else Qt.CheckState.Unchecked)
         do_not_backup_previous_cb.setCheckState(check_state)
         do_not_backup_previous_cb.stateChanged.connect(self.dnbp_changed)
-        current_backups_gb_layout.addWidget(do_not_backup_previous_cb, 2, 0, 1,
-            3)
+        current_backups_gb_layout.addWidget(do_not_backup_previous_cb, 2, 0, 1, 3)
         self.do_not_backup_previous_cb = do_not_backup_previous_cb
 
         manual_backups_gb = QGroupBox()
@@ -128,27 +123,26 @@ class BackupsTab(QTabWidget):
         self.automatic_backups_gb = automatic_backups_gb
 
         backup_on_launch_cb = QCheckBox()
-        check_state = (Qt.CheckState.Checked if config_true(get_config_value(
-            'backup_on_launch', 'False')) else Qt.CheckState.Unchecked)
+        check_state = (Qt.CheckState.Checked if config_true(
+            get_config_value('backup_on_launch', 'False')) else Qt.CheckState.Unchecked)
         backup_on_launch_cb.setCheckState(check_state)
         backup_on_launch_cb.stateChanged.connect(self.bol_changed)
         automatic_backups_layout.addWidget(backup_on_launch_cb, 0, 0)
         self.backup_on_launch_cb = backup_on_launch_cb
 
         backup_on_end_cb = QCheckBox()
-        check_state = (Qt.CheckState.Checked if config_true(get_config_value(
-            'backup_on_end', 'False')) else Qt.CheckState.Unchecked)
+        check_state = (Qt.CheckState.Checked if config_true(
+            get_config_value('backup_on_end', 'False')) else Qt.CheckState.Unchecked)
         backup_on_end_cb.setCheckState(check_state)
         backup_on_end_cb.stateChanged.connect(self.boe_changed)
         automatic_backups_layout.addWidget(backup_on_end_cb, 1, 0)
         self.backup_on_end_cb = backup_on_end_cb
 
         backup_on_end = check_state
-        keep_launcher_open = config_true(get_config_value('keep_launcher_open',
-            'False'))
+        keep_launcher_open = config_true(get_config_value('keep_launcher_open', 'False'))
 
         backup_on_end_warning_label = QLabel()
-        icon = QApplication.style().standardIcon(QStyle.SP_MessageBoxWarning)
+        icon = QApplication.style().standardIcon(QStyle.StandardPixmap.SP_MessageBoxWarning)
         backup_on_end_warning_label.setPixmap(icon.pixmap(16, 16))
         if not (backup_on_end and not keep_launcher_open):
             backup_on_end_warning_label.hide()
@@ -156,8 +150,8 @@ class BackupsTab(QTabWidget):
         self.backup_on_end_warning_label = backup_on_end_warning_label
 
         backup_before_update_cb = QCheckBox()
-        check_state = (Qt.CheckState.Checked if config_true(get_config_value(
-            'backup_before_update', 'False')) else Qt.CheckState.Unchecked)
+        check_state = (Qt.CheckState.Checked if config_true(
+            get_config_value('backup_before_update', 'False')) else Qt.CheckState.Unchecked)
         backup_before_update_cb.setCheckState(check_state)
         backup_before_update_cb.stateChanged.connect(self.bbu_changed)
         automatic_backups_layout.addWidget(backup_before_update_cb, 2, 0)
@@ -175,8 +169,7 @@ class BackupsTab(QTabWidget):
         max_auto_backups_spinbox = QSpinBox()
         max_auto_backups_spinbox.setMinimum(1)
         max_auto_backups_spinbox.setMaximum(1000)
-        max_auto_backups_spinbox.setValue(int(get_config_value(
-            'max_auto_backups', '6')))
+        max_auto_backups_spinbox.setValue(int(get_config_value('max_auto_backups', '6')))
         max_auto_backups_spinbox.valueChanged.connect(self.mabs_changed)
         mab_layout.addWidget(max_auto_backups_spinbox)
         self.max_auto_backups_spinbox = max_auto_backups_spinbox
@@ -203,10 +196,10 @@ class BackupsTab(QTabWidget):
         self.refresh_list_button.setText(_('Refresh list'))
         self.delete_button.setText(_('Delete backup'))
         self.do_not_backup_previous_cb.setText(_('Do not backup the current '
-            'saves before restoring a backup'))
-        self.backups_table.setHorizontalHeaderLabels((_('Name'),
-            _('Modified'), _('Worlds'), _('Characters'), _('Actual size'),
-            _('Compressed size'), _('Compression ratio'), _('Modified date')))
+                                                 'saves before restoring a backup'))
+        self.backups_table.setHorizontalHeaderLabels((_('Name'), _('Modified'), _('Worlds'), _('Characters'),
+                                                      _('Actual size'), _('Compressed size'), _('Compression ratio'),
+                                                      _('Modified date')))
 
         self.name_label.setText(_('Name:'))
         self.backup_current_button.setText(_('Backup current saves'))
@@ -216,11 +209,11 @@ class BackupsTab(QTabWidget):
         self.backup_before_update_cb.setText(_('Backup saves before updating'))
 
         self.backup_on_end_warning_label.setToolTip(_('This option will only '
-            'work if you also have the option to keep the launcher opened '
-            'after launching the game in the settings tab.'))
+                                                      'work if you also have the option to keep the launcher opened '
+                                                      'after launching the game in the settings tab.'))
 
         self.max_auto_backups_label.setText(_('Maximum automatic backups '
-            'count:'))
+                                              'count:'))
 
     def get_main_window(self):
         return self.parentWidget().parentWidget().parentWidget()
@@ -248,12 +241,10 @@ class BackupsTab(QTabWidget):
     def enable_tab(self):
         self.backups_table.setEnabled(True)
 
-        if (self.game_dir is not None and os.path.isdir(
-            os.path.join(self.game_dir, 'save_backups'))):
+        if (self.game_dir is not None and os.path.isdir(os.path.join(self.game_dir, 'save_backups'))):
             self.refresh_list_button.setEnabled(True)
 
-        if (self.game_dir is not None and os.path.isdir(
-            os.path.join(self.game_dir, 'save'))):
+        if (self.game_dir is not None and os.path.isdir(os.path.join(self.game_dir, 'save'))):
             self.backup_current_button.setEnabled(True)
 
         selection_model = self.backups_table.selectionModel()
@@ -283,14 +274,13 @@ class BackupsTab(QTabWidget):
 
         set_config_value('backup_on_end', str(checked))
 
-        keep_launcher_open = config_true(get_config_value('keep_launcher_open',
-            'False'))
+        keep_launcher_open = config_true(get_config_value('keep_launcher_open', 'False'))
 
         if not (checked and not keep_launcher_open):
             self.backup_on_end_warning_label.hide()
         else:
             self.backup_on_end_warning_label.show()
-    
+
     def bbu_changed(self, state):
         set_config_value('backup_before_update', str(state != Qt.CheckState.Unchecked))
 
@@ -311,8 +301,7 @@ class BackupsTab(QTabWidget):
                 self.completed.emit()
 
         if self.backup_searching:
-            if (self.compressing_timer is not None and
-                self.compressing_timer.isActive()):
+            if (self.compressing_timer is not None and self.compressing_timer.isActive()):
                 self.compressing_timer.stop()
 
             self.backup_searching = False
@@ -396,8 +385,7 @@ class BackupsTab(QTabWidget):
             if not os.path.isfile(selected_info['path']):
                 return
 
-            backup_previous = not config_true(get_config_value(
-                'do_not_backup_previous', 'False'))
+            backup_previous = not config_true(get_config_value('do_not_backup_previous', 'False'))
 
             if backup_previous:
                 '''
@@ -424,17 +412,14 @@ class BackupsTab(QTabWidget):
                             filename_key = alphanum_key(filename_lower)
 
                             counter = filename_key[-1:][0]
-                            if len(filename_key) > 1 and isinstance(counter,
-                                int):
+                            if len(filename_key) > 1 and isinstance(counter, int):
                                 filename_key = filename_key[:-1]
 
                                 if name_key == filename_key:
                                     max_counter = max(max_counter, counter)
 
-                    new_backup_name = (before_last_restore_name +
-                        str(max_counter + 1))
-                    new_backup_path = os.path.join(backup_dir,
-                        new_backup_name + '.zip')
+                    new_backup_name = (before_last_restore_name + str(max_counter + 1))
+                    new_backup_path = os.path.join(backup_dir, new_backup_name + '.zip')
 
                     if not retry_rename(selected_info['path'], new_backup_path):
                         return
@@ -474,11 +459,9 @@ class BackupsTab(QTabWidget):
         self.temp_save_dir = None
         save_dir = self.get_save_dir()
         if os.path.isdir(save_dir):
-            temp_save_dir = os.path.join(self.game_dir, 'save-{0}'.format(
-                '%08x' % random.randrange(16**8)))
+            temp_save_dir = os.path.join(self.game_dir, 'save-{0}'.format('%08x' % random.randrange(16 ** 8)))
             while os.path.exists(temp_save_dir):
-                temp_save_dir = os.path.join(self.game_dir, 'save-{0}'.format(
-                    '%08x' % random.randrange(16**8)))
+                temp_save_dir = os.path.join(self.game_dir, 'save-{0}'.format('%08x' % random.randrange(16 ** 8)))
 
             if not retry_rename(save_dir, temp_save_dir):
                 status_bar.showMessage(_('Could not rename the save directory'))
@@ -506,24 +489,21 @@ class BackupsTab(QTabWidget):
         self.extracting_label = extracting_label
 
         extracting_speed_label = QLabel()
-        extracting_speed_label.setText(_('{bytes_sec}/s'
-            ).format(bytes_sec=sizeof_fmt(0)))
+        extracting_speed_label.setText(_('{bytes_sec}/s').format(bytes_sec=sizeof_fmt(0)))
         status_bar.addWidget(extracting_speed_label)
         self.extracting_speed_label = extracting_speed_label
 
         extracting_size_label = QLabel()
-        extracting_size_label.setText(
-            '{bytes_read}/{total_bytes}'
-            .format(bytes_read=sizeof_fmt(0), total_bytes=sizeof_fmt(self.total_extract_size))
-        )
+        extracting_size_label.setText('{bytes_read}/{total_bytes}'.format(bytes_read=sizeof_fmt(0),
+                                                                          total_bytes=sizeof_fmt(
+                                                                              self.total_extract_size)))
         status_bar.addWidget(extracting_size_label)
-        self.extracting_size_label = (
-            extracting_size_label)
+        self.extracting_size_label = (extracting_size_label)
 
         progress_bar = QProgressBar()
         self.filestep = 0
-        self.scale_factor = max(0,int(self.total_extract_size.bit_length()) - 31) 
-        progress_bar.setRange(0, self.total_extract_size >> self.scale_factor) 
+        self.scale_factor = max(0, int(self.total_extract_size.bit_length()) - 31)
+        progress_bar.setRange(0, self.total_extract_size >> self.scale_factor)
         progress_bar.setValue(0)
         status_bar.addWidget(progress_bar)
         self.extracting_progress_bar = progress_bar
@@ -564,13 +544,11 @@ class BackupsTab(QTabWidget):
             try:
                 if self.extracting_backup:
                     extracting_element = self.extracting_infolist.popleft()
-                    self.extracting_label.setText(_('Extracting {filename}'
-                        ).format(filename=extracting_element.filename))
+                    self.extracting_label.setText(
+                        _('Extracting {filename}').format(filename=extracting_element.filename))
                     self.next_extract_file = extracting_element
 
-                    extracting_thread = ExtractingThread(
-                        self.extracting_zipfile, extracting_element,
-                        self.extract_dir)
+                    extracting_thread = ExtractingThread(self.extracting_zipfile, extracting_element, self.extract_dir)
                     extracting_thread.completed.connect(completed_extract)
                     self.extracting_thread = extracting_thread
 
@@ -585,22 +563,19 @@ class BackupsTab(QTabWidget):
                 main_window = self.get_main_window()
                 status_bar = main_window.statusBar()
 
-                status_bar.showMessage(_('{backup_name} backup restored'
-                    ).format(backup_name=backup_name))
+                status_bar.showMessage(_('{backup_name} backup restored').format(backup_name=backup_name))
 
         def completed_extract():
             self.extract_size += self.next_extract_file.file_size
-            
+
             self.filestep += 1
             if self.filestep == 100:
                 self.filestep = 0
-                self.extracting_progress_bar.setValue(self.extract_size >> self.scale_factor) 
+                self.extracting_progress_bar.setValue(self.extract_size >> self.scale_factor)
 
                 self.extracting_size_label.setText(
-                    '{bytes_read}/{total_bytes}'
-                    .format(bytes_read=sizeof_fmt(self.extract_size),
-                            total_bytes=sizeof_fmt(self.total_extract_size))
-                )
+                    '{bytes_read}/{total_bytes}'.format(bytes_read=sizeof_fmt(self.extract_size),
+                                                        total_bytes=sizeof_fmt(self.total_extract_size)))
 
                 delta_bytes = self.extract_size - self.last_extract_bytes
                 delta_time = datetime.utcnow() - self.last_extract
@@ -608,8 +583,7 @@ class BackupsTab(QTabWidget):
                     delta_time = timedelta.resolution
 
                 bytes_secs = delta_bytes / delta_time.total_seconds()
-                self.extracting_speed_label.setText(_('{bytes_sec}/s'
-                    ).format(bytes_sec=sizeof_fmt(bytes_secs)))
+                self.extracting_speed_label.setText(_('{bytes_sec}/s').format(bytes_sec=sizeof_fmt(bytes_secs)))
 
             self.last_extract_bytes = self.extract_size
             self.last_extract = datetime.utcnow()
@@ -667,15 +641,13 @@ class BackupsTab(QTabWidget):
         confirm_msgbox = QMessageBox()
         confirm_msgbox.setWindowTitle(_('Delete backup'))
         confirm_msgbox.setText(_('This will delete the backup file. It '
-            'cannot be undone.'))
+                                 'cannot be undone.'))
         confirm_msgbox.setInformativeText(_('Are you sure you want to '
-            'delete the <strong>{filename}</strong> backup?').format(
+                                            'delete the <strong>{filename}</strong> backup?').format(
             filename=selected_info['path']))
-        confirm_msgbox.addButton(_('Delete the backup'),
-            QMessageBox.YesRole)
-        confirm_msgbox.addButton(_('I want to keep the backup'),
-            QMessageBox.NoRole)
-        confirm_msgbox.setIcon(QMessageBox.Warning)
+        confirm_msgbox.addButton(_('Delete the backup'), QMessageBox.ButtonRole.YesRole)
+        confirm_msgbox.addButton(_('I want to keep the backup'), QMessageBox.ButtonRole.NoRole)
+        confirm_msgbox.setIcon(QMessageBox.Icon.Warning)
 
         if confirm_msgbox.exec() == 0:
             main_window = self.get_main_window()
@@ -691,8 +663,7 @@ class BackupsTab(QTabWidget):
 
     def backup_current_clicked(self):
         if self.manual_backup and self.backup_searching:
-            if (self.compressing_timer is not None and
-                self.compressing_timer.isActive()):
+            if (self.compressing_timer is not None and self.compressing_timer.isActive()):
                 self.compressing_timer.stop()
 
             self.backup_searching = False
@@ -760,9 +731,8 @@ class BackupsTab(QTabWidget):
     def prune_auto_backups(self):
         if self.game_dir is None:
             return
-        
-        max_auto_backups = max(int(get_config_value('max_auto_backups', '6'))
-            , 1)
+
+        max_auto_backups = max(int(get_config_value('max_auto_backups', '6')), 1)
 
         search_start = (_('auto') + '_').lower()
 
@@ -778,11 +748,7 @@ class BackupsTab(QTabWidget):
                 filename_lower = filename.lower()
 
                 if filename_lower.startswith(search_start):
-                    auto_backups.append({
-                        'path': entry.path,
-                        'modified': datetime.fromtimestamp(
-                            entry.stat().st_mtime)
-                    })
+                    auto_backups.append({'path': entry.path, 'modified': datetime.fromtimestamp(entry.stat().st_mtime)})
 
         if len(auto_backups) >= max_auto_backups:
             # Remove backups to have a total of max_auto_backups - 1
@@ -830,7 +796,7 @@ class BackupsTab(QTabWidget):
             if os.path.isfile(self.backup_path):
                 if not delete_path(self.backup_path):
                     status_bar.showMessage(_('Could not delete previous '
-                        'backup archive'))
+                                             'backup archive'))
                     return
         else:
             '''
@@ -934,49 +900,39 @@ class BackupsTab(QTabWidget):
                         self.filestep += 1
                         if self.filestep == 100:
                             self.filestep = 0
-                            self.compressing_label.setText(
-                                _('Found {filename} in {path}').format(
-                                    filename=entry.name,
-                                    path=os.path.dirname(entry.path)))
+                            self.compressing_label.setText(_('Found {filename} in {path}').format(filename=entry.name,
+                                path=os.path.dirname(entry.path)))
                         self.backup_files.append(entry.path)
                         self.total_backup_size += entry.stat().st_size
-                        self.backup_file_sizes[entry.path
-                            ] = entry.stat().st_size
+                        self.backup_file_sizes[entry.path] = entry.stat().st_size
                         self.total_files += 1
                     elif entry.is_dir():
                         self.next_backup_scans.append(entry.path)
                 except StopIteration:
                     try:
-                        self.backup_scan = scandir(
-                            self.next_backup_scans.popleft())
+                        self.backup_scan = scandir(self.next_backup_scans.popleft())
                     except IndexError:
                         self.backup_searching = False
                         self.backup_compressing = True
 
-                        self.compressing_label.setText(
-                            _('Compressing save files'))
+                        self.compressing_label.setText(_('Compressing save files'))
 
                         compressing_speed_label = QLabel()
-                        compressing_speed_label.setText(_('{bytes_sec}/s'
-                            ).format(bytes_sec=sizeof_fmt(0)))
+                        compressing_speed_label.setText(_('{bytes_sec}/s').format(bytes_sec=sizeof_fmt(0)))
                         status_bar.addWidget(compressing_speed_label)
-                        self.compressing_speed_label = (
-                            compressing_speed_label)
+                        self.compressing_speed_label = (compressing_speed_label)
 
                         compressing_size_label = QLabel()
-                        compressing_size_label.setText(
-                            '{bytes_read}/{total_bytes}'
-                            .format(bytes_read=sizeof_fmt(0),
-                                    total_bytes=sizeof_fmt(self.total_backup_size))
-                        )
+                        compressing_size_label.setText('{bytes_read}/{total_bytes}'.format(bytes_read=sizeof_fmt(0),
+                                                                                           total_bytes=sizeof_fmt(
+                                                                                               self.total_backup_size)))
                         status_bar.addWidget(compressing_size_label)
-                        self.compressing_size_label = (
-                            compressing_size_label)
+                        self.compressing_size_label = (compressing_size_label)
 
                         progress_bar = QProgressBar()
                         self.filestep = 0
-                        self.scale_factor = max(0,int(self.total_backup_size.bit_length()) - 31) 
-                        progress_bar.setRange(0, self.total_backup_size >> self.scale_factor) 
+                        self.scale_factor = max(0, int(self.total_backup_size.bit_length()) - 31)
+                        progress_bar.setRange(0, self.total_backup_size >> self.scale_factor)
                         progress_bar.setValue(0)
                         status_bar.addWidget(progress_bar)
                         self.compressing_progress_bar = progress_bar
@@ -1022,11 +978,9 @@ class BackupsTab(QTabWidget):
                     relpath = os.path.relpath(next_file, self.game_dir)
                     self.next_backup_file = next_file
 
-                    self.compressing_label.setText(
-                        _('Compressing {filename}').format(filename=relpath))
+                    self.compressing_label.setText(_('Compressing {filename}').format(filename=relpath))
 
-                    compress_thread = CompressThread(self.backup_file,
-                        next_file, relpath)
+                    compress_thread = CompressThread(self.backup_file, next_file, relpath)
                     compress_thread.completed.connect(completed_compress)
                     self.compress_thread = compress_thread
 
@@ -1055,13 +1009,11 @@ class BackupsTab(QTabWidget):
             if self.filestep == 100:
                 self.filestep = 0
 
-                self.compressing_progress_bar.setValue(self.comp_size >> self.scale_factor) 
+                self.compressing_progress_bar.setValue(self.comp_size >> self.scale_factor)
 
                 self.compressing_size_label.setText(
-                    '{bytes_read}/{total_bytes}'
-                    .format(bytes_read=sizeof_fmt(self.comp_size),
-                            total_bytes=sizeof_fmt(self.total_backup_size))
-                )
+                    '{bytes_read}/{total_bytes}'.format(bytes_read=sizeof_fmt(self.comp_size),
+                                                        total_bytes=sizeof_fmt(self.total_backup_size)))
 
                 delta_bytes = self.comp_size - self.last_comp_bytes
                 delta_time = datetime.utcnow() - self.last_comp
@@ -1069,16 +1021,14 @@ class BackupsTab(QTabWidget):
                     delta_time = timedelta.resolution
 
                 bytes_secs = delta_bytes / delta_time.total_seconds()
-                self.compressing_speed_label.setText(_('{bytes_sec}/s'
-                    ).format(bytes_sec=sizeof_fmt(bytes_secs)))
+                self.compressing_speed_label.setText(_('{bytes_sec}/s').format(bytes_sec=sizeof_fmt(bytes_secs)))
 
                 self.last_comp_bytes = self.comp_size
                 self.last_comp = datetime.utcnow()
 
             backup_next_file()
 
-        self.backup_file = zipfile.ZipFile(self.backup_path, 'w',
-            zipfile.ZIP_DEFLATED)
+        self.backup_file = zipfile.ZipFile(self.backup_path, 'w', zipfile.ZIP_DEFLATED)
         backup_next_file()
 
     def finish_backup_saves(self):
@@ -1122,7 +1072,7 @@ class BackupsTab(QTabWidget):
         save_dir = os.path.join(self.game_dir, 'save')
         session = get_config_value('session_directory')
 
-        #For compatibility with 1.6.3
+        # For compatibility with 1.6.3
         if session == 'default_session':
             session = self.game_dir
 
@@ -1170,7 +1120,7 @@ class BackupsTab(QTabWidget):
         backup_dir = os.path.join(self.game_dir, 'save_backups')
         session = get_config_value('session_directory')
 
-        #For compatibility with 1.6.3
+        # For compatibility with 1.6.3
         if session == 'default_session':
             session = self.game_dir
 
@@ -1216,8 +1166,7 @@ class BackupsTab(QTabWidget):
 
         self.refresh_list_button.setEnabled(True)
 
-        if (self.update_backups_timer is not None
-            and self.update_backups_timer.isActive()):
+        if (self.update_backups_timer is not None and self.update_backups_timer.isActive()):
             self.update_backups_timer.stop()
 
         timer = QTimer(self)
@@ -1226,6 +1175,7 @@ class BackupsTab(QTabWidget):
         self.backups_scan = scandir(backup_dir)
 
         save_dir_name = os.path.basename(os.path.normpath(self.get_save_dir()))
+
         def timeout():
             try:
                 entry = next(self.backups_scan)
@@ -1262,13 +1212,10 @@ class BackupsTab(QTabWidget):
                     # We found a valid backup
 
                     compressed_size = entry.stat().st_size
-                    modified_date = datetime.fromtimestamp(
-                        entry.stat().st_mtime)
-                    formated_date = format_datetime(modified_date,
-                        format='short', locale=self.app_locale)
+                    modified_date = datetime.fromtimestamp(entry.stat().st_mtime)
+                    formated_date = format_datetime(modified_date, format='short', locale=self.app_locale)
                     arrow_date = arrow.get(entry.stat().st_mtime)
-                    human_delta = safe_humanize(arrow_date, arrow.utcnow(),
-                        locale=self.app_locale)
+                    human_delta = safe_humanize(arrow_date, arrow.utcnow(), locale=self.app_locale)
 
                     row_index = self.backups_table.rowCount()
                     self.backups_table.insertRow(row_index)
@@ -1278,26 +1225,19 @@ class BackupsTab(QTabWidget):
                     if uncompressed_size == 0:
                         compression_ratio = 0
                     else:
-                        compression_ratio = 1.0 - (compressed_size /
-                            uncompressed_size)
+                        compression_ratio = 1.0 - (compressed_size / uncompressed_size)
                     rounded_ratio = round(compression_ratio, 4)
-                    ratio_percent = format_percent(rounded_ratio,
-                        format='#.##%', locale=self.app_locale)
+                    ratio_percent = format_percent(rounded_ratio, format='#.##%', locale=self.app_locale)
 
                     if self.previous_selection is not None:
                         if entry.path == self.previous_selection:
                             self.previous_selection_index = row_index
 
-                    fields = (
-                        (filename, alphanum_key(filename)),
-                        (human_delta, modified_date),
-                        (str(len(worlds_set)), len(worlds_set)),
-                        (str(character_count), character_count),
-                        (sizeof_fmt(uncompressed_size), uncompressed_size),
-                        (sizeof_fmt(compressed_size), compressed_size),
-                        (ratio_percent, compression_ratio),
-                        (formated_date, modified_date)
-                        )
+                    fields = ((filename, alphanum_key(filename)), (human_delta, modified_date),
+                              (str(len(worlds_set)), len(worlds_set)), (str(character_count), character_count),
+                              (sizeof_fmt(uncompressed_size), uncompressed_size),
+                              (sizeof_fmt(compressed_size), compressed_size), (ratio_percent, compression_ratio),
+                              (formated_date, modified_date))
 
                     for index, value in enumerate(fields):
                         item = SortEnabledTableWidgetItem(value[0], value[1])
@@ -1305,10 +1245,7 @@ class BackupsTab(QTabWidget):
                         self.backups_table.setItem(row_index, index, item)
 
                         if index == 0:
-                            self.backups[item] = {
-                                'path': entry.path,
-                                'actual_size': uncompressed_size
-                            }
+                            self.backups[item] = {'path': entry.path, 'actual_size': uncompressed_size}
 
             except StopIteration:
                 self.update_backups_timer.stop()
@@ -1318,18 +1255,14 @@ class BackupsTab(QTabWidget):
                     model = selection_model.model()
 
                     first_index = model.index(self.previous_selection_index, 0)
-                    last_index = model.index(self.previous_selection_index,
-                        self.backups_table.columnCount() - 1)
+                    last_index = model.index(self.previous_selection_index, self.backups_table.columnCount() - 1)
                     row_selection = QItemSelection(first_index, last_index)
 
-                    selection_model.select(row_selection,
-                        QItemSelectionModel.Select)
-                    selection_model.setCurrentIndex(first_index,
-                        QItemSelectionModel.Select)
+                    selection_model.select(row_selection, QItemSelectionModel.Select)
+                    selection_model.setCurrentIndex(first_index, QItemSelectionModel.Select)
 
                 self.backups_table.sortItems(1, Qt.SortOrder.DescendingOrder)
-                self.backups_table.horizontalHeader().setSortIndicatorShown(
-                    True)
+                self.backups_table.horizontalHeader().setSortIndicatorShown(True)
 
                 if self.after_update_backups is not None:
                     self.after_update_backups()
@@ -1368,11 +1301,7 @@ def retry_rename(src, dst):
 <p>The launcher failed to rename the following file: {src} to {dst}</p>
 <p>When trying to rename or access {filename}, the launcher raised the
 following error: {error}</p>
-''').format(
-    src=html.escape(src),
-    dst=html.escape(dst),
-    filename=html.escape(e.filename),
-    error=html.escape(e.strerror))
+''').format(src=html.escape(src), dst=html.escape(dst), filename=html.escape(e.filename), error=html.escape(e.strerror))
 
             if process is None:
                 text = text + _('''
@@ -1386,12 +1315,10 @@ that file. You might need to end it if you want to retry.</p>
 
             retry_msgbox.setText(text)
             retry_msgbox.setInformativeText(_('Do you want to retry renaming '
-                'this file?'))
-            retry_msgbox.addButton(_('Retry renaming the file'),
-                QMessageBox.YesRole)
-            retry_msgbox.addButton(_('Cancel the operation'),
-                QMessageBox.NoRole)
-            retry_msgbox.setIcon(QMessageBox.Critical)
+                                              'this file?'))
+            retry_msgbox.addButton(_('Retry renaming the file'), QMessageBox.ButtonRole.YesRole)
+            retry_msgbox.addButton(_('Cancel the operation'), QMessageBox.ButtonRole.NoRole)
+            retry_msgbox.setIcon(QMessageBox.Icon.Critical)
 
             if retry_msgbox.exec() == 1:
                 return False

--- a/cddagl/ui/views/backups.py
+++ b/cddagl/ui/views/backups.py
@@ -158,7 +158,7 @@ class BackupsTab(QTabWidget):
         self.backup_before_update_cb = backup_before_update_cb
 
         mab_group = QWidget()
-        mab_group.setSizePolicy(QSizePolicy.Maximum, QSizePolicy.Maximum)
+        mab_group.setSizePolicy(QSizePolicy.Policy.Maximum, QSizePolicy.Policy.Maximum)
         mab_layout = QHBoxLayout()
         mab_layout.setContentsMargins(0, 0, 0, 0)
 
@@ -264,13 +264,13 @@ class BackupsTab(QTabWidget):
         set_config_value('max_auto_backups', value)
 
     def dnbp_changed(self, state):
-        set_config_value('do_not_backup_previous', str(state != Qt.CheckState.Unchecked))
+        set_config_value('do_not_backup_previous', str(state != Qt.CheckState.Unchecked.value))
 
     def bol_changed(self, state):
-        set_config_value('backup_on_launch', str(state != Qt.CheckState.Unchecked))
+          set_config_value('backup_on_launch', str(state != Qt.CheckState.Unchecked.value))
 
     def boe_changed(self, state):
-        checked = state != Qt.CheckState.Unchecked
+        checked = state != Qt.CheckState.Unchecked.value
 
         set_config_value('backup_on_end', str(checked))
 
@@ -282,7 +282,7 @@ class BackupsTab(QTabWidget):
             self.backup_on_end_warning_label.show()
 
     def bbu_changed(self, state):
-        set_config_value('backup_before_update', str(state != Qt.CheckState.Unchecked))
+        set_config_value('backup_before_update', str(state != Qt.CheckState.Unchecked.value))
 
     def restore_button_clicked(self):
         class WaitingThread(QThread):

--- a/cddagl/ui/views/backups.py
+++ b/cddagl/ui/views/backups.py
@@ -288,13 +288,10 @@ class BackupsTab(QTabWidget):
         class WaitingThread(QThread):
             completed = Signal()
 
-            def __init__(self, wthread):
-                super(WaitingThread, self).__init__()
+            def __init__(self, wthread, parent):
+                super(WaitingThread, self).__init__(parent)
 
                 self.wthread = wthread
-
-            def __del__(self):
-                self.wait()
 
             def run(self):
                 self.wthread.wait()
@@ -325,8 +322,9 @@ class BackupsTab(QTabWidget):
                     delete_path(self.backup_path)
                     self.compress_thread = None
 
-                waiting_thread = WaitingThread(self.compress_thread)
+                waiting_thread = WaitingThread(self.compress_thread, self)
                 waiting_thread.completed.connect(completed)
+                waiting_thread.finished.connect(waiting_thread.deleteLater)
                 self.waiting_thread = waiting_thread
 
                 waiting_thread.start()
@@ -358,8 +356,9 @@ class BackupsTab(QTabWidget):
                     self.finish_restore_backup()
                     self.extracting_thread = None
 
-                waiting_thread = WaitingThread(self.extracting_thread)
+                waiting_thread = WaitingThread(self.extracting_thread, self)
                 waiting_thread.completed.connect(completed)
+                waiting_thread.finished.connect(waiting_thread.deleteLater)
                 self.waiting_thread = waiting_thread
 
                 waiting_thread.start()
@@ -526,15 +525,12 @@ class BackupsTab(QTabWidget):
         class ExtractingThread(QThread):
             completed = Signal()
 
-            def __init__(self, zfile, element, dir):
-                super(ExtractingThread, self).__init__()
+            def __init__(self, zfile, element, dir, parent):
+                super(ExtractingThread, self).__init__(parent)
 
                 self.zfile = zfile
                 self.element = element
                 self.dir = dir
-
-            def __del__(self):
-                self.wait()
 
             def run(self):
                 self.zfile.extract(self.element, self.dir)
@@ -548,8 +544,10 @@ class BackupsTab(QTabWidget):
                         _('Extracting {filename}').format(filename=extracting_element.filename))
                     self.next_extract_file = extracting_element
 
-                    extracting_thread = ExtractingThread(self.extracting_zipfile, extracting_element, self.extract_dir)
+                    extracting_thread = ExtractingThread(self.extracting_zipfile, extracting_element,
+                                                         self.extract_dir, self)
                     extracting_thread.completed.connect(completed_extract)
+                    extracting_thread.finished.connect(extracting_thread.deleteLater)
                     self.extracting_thread = extracting_thread
 
                     extracting_thread.start()
@@ -679,13 +677,11 @@ class BackupsTab(QTabWidget):
             class WaitingThread(QThread):
                 completed = Signal()
 
-                def __init__(self, wthread):
-                    super(WaitingThread, self).__init__()
+                def __init__(self, wthread, parent):
+                    super(WaitingThread, self).__init__(parent)
 
                     self.wthread = wthread
 
-                def __del__(self):
-                    self.wait()
 
                 def run(self):
                     self.wthread.wait()
@@ -700,8 +696,9 @@ class BackupsTab(QTabWidget):
                     delete_path(self.backup_path)
                     self.compress_thread = None
 
-                waiting_thread = WaitingThread(self.compress_thread)
+                waiting_thread = WaitingThread(self.compress_thread, self)
                 waiting_thread.completed.connect(completed)
+                waiting_thread.finished.connect(waiting_thread.deleteLater)
                 self.waiting_thread = waiting_thread
 
                 waiting_thread.start()
@@ -957,15 +954,12 @@ class BackupsTab(QTabWidget):
         class CompressThread(QThread):
             completed = Signal()
 
-            def __init__(self, zfile, filename, arcname):
-                super(CompressThread, self).__init__()
+            def __init__(self, zfile, filename, arcname, parent):
+                super(CompressThread, self).__init__(parent)
 
                 self.zfile = zfile
                 self.filename = filename
                 self.arcname = arcname
-
-            def __del__(self):
-                self.wait()
 
             def run(self):
                 self.zfile.write(self.filename, self.arcname)
@@ -980,8 +974,9 @@ class BackupsTab(QTabWidget):
 
                     self.compressing_label.setText(_('Compressing {filename}').format(filename=relpath))
 
-                    compress_thread = CompressThread(self.backup_file, next_file, relpath)
+                    compress_thread = CompressThread(self.backup_file, next_file, relpath, self)
                     compress_thread.completed.connect(completed_compress)
+                    compress_thread.finished.connect(compress_thread.deleteLater)
                     self.compress_thread = compress_thread
 
                     compress_thread.start()

--- a/cddagl/ui/views/dialogs.py
+++ b/cddagl/ui/views/dialogs.py
@@ -52,7 +52,7 @@ class BrowserDownloadDialog(QDialog):
         url_tb.setReadOnly(True)
         url_tb.setOpenExternalLinks(True)
         url_tb.setMaximumHeight(23)
-        url_tb.setLineWrapMode(QTextEdit.NoWrap)
+        url_tb.setLineWrapMode(QTextEdit.LineWrapMode.NoWrap)
         url_tb.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
         layout.addWidget(url_tb, 2, 0, 1, 2)
         self.url_tb = url_tb
@@ -109,7 +109,7 @@ class BrowserDownloadDialog(QDialog):
         self.setWindowTitle(_('Browser download'))
 
     def set_download_path(self):
-        options = QFileDialog.DontResolveSymlinks
+        options = QFileDialog.Option.DontResolveSymlinks
         selected_file, selected_filter = QFileDialog.getOpenFileName(self,
             _('Downloaded archive'), self.download_path_le.text(),
             _('Archive files {formats}').format(formats='(*.zip *.rar *.7z)'),
@@ -131,8 +131,8 @@ class BrowserDownloadDialog(QDialog):
 
             filenotfound_msgbox.setText(text)
             filenotfound_msgbox.addButton(_('I will try again'),
-                QMessageBox.AcceptRole)
-            filenotfound_msgbox.setIcon(QMessageBox.Warning)
+                QMessageBox.ButtonRole.AcceptRole)
+            filenotfound_msgbox.setIcon(QMessageBox.Icon.Warning)
             filenotfound_msgbox.exec()
 
             return

--- a/cddagl/ui/views/main.py
+++ b/cddagl/ui/views/main.py
@@ -533,13 +533,10 @@ antivirus whitelist or select the action to trust this binary when detected.</p>
             class ProcessWaitThread(QThread):
                 ended = Signal()
 
-                def __init__(self, process):
-                    super(ProcessWaitThread, self).__init__()
+                def __init__(self, process, parent):
+                    super(ProcessWaitThread, self).__init__(parent)
 
                     self.process = process
-
-                def __del__(self):
-                    self.wait()
 
                 def run(self):
                     self.process.wait()
@@ -548,8 +545,9 @@ antivirus whitelist or select the action to trust this binary when detected.</p>
             def process_ended():
                 self.game_ended()
 
-            process_wait_thread = ProcessWaitThread(self.game_process)
+            process_wait_thread = ProcessWaitThread(self.game_process, self)
             process_wait_thread.ended.connect(process_ended)
+            process_wait_thread.finished.connect(process_wait_thread.deleteLater)
             process_wait_thread.start()
 
             self.process_wait_thread = process_wait_thread
@@ -960,13 +958,10 @@ antivirus whitelist or select the action to trust this binary when detected.</p>
             class ProcessWaitThread(QThread):
                 ended = Signal()
 
-                def __init__(self, pid):
-                    super(ProcessWaitThread, self).__init__()
+                def __init__(self, pid, parent):
+                    super(ProcessWaitThread, self).__init__(parent)
 
                     self.pid = pid
-
-                def __del__(self):
-                    self.wait()
 
                 def run(self):
                     wait_for_pid(self.pid)
@@ -1001,8 +996,9 @@ antivirus whitelist or select the action to trust this binary when detected.</p>
 
                     backups_tab.backup_saves(name)
 
-            process_wait_thread = ProcessWaitThread(self.game_process_id)
+            process_wait_thread = ProcessWaitThread(self.game_process_id, self)
             process_wait_thread.ended.connect(process_ended)
+            process_wait_thread.finished.connect(process_wait_thread.deleteLater)
             process_wait_thread.start()
 
             self.process_wait_thread = process_wait_thread
@@ -2104,13 +2100,10 @@ class UpdateGroupBox(QGroupBox):
                 invalid = Signal()
                 not_downloaded = Signal()
 
-                def __init__(self, downloaded_file):
-                    super(TestingZipThread, self).__init__()
+                def __init__(self, downloaded_file, parent):
+                    super(TestingZipThread, self).__init__(parent)
 
                     self.downloaded_file = downloaded_file
-
-                def __del__(self):
-                    self.wait()
 
                 def run(self):
                     try:
@@ -2150,10 +2143,11 @@ class UpdateGroupBox(QGroupBox):
                 delete_path(download_dir)
                 self.finish_updating()
 
-            test_thread = TestingZipThread(self.downloaded_file)
+            test_thread = TestingZipThread(self.downloaded_file, self)
             test_thread.completed.connect(completed_test)
             test_thread.invalid.connect(invalid)
             test_thread.not_downloaded.connect(not_downloaded)
+            test_thread.finished.connect(test_thread.deleteLater)
             test_thread.start()
 
             self.test_thread = test_thread

--- a/cddagl/ui/views/main.py
+++ b/cddagl/ui/views/main.py
@@ -145,7 +145,7 @@ class GameDirGroupBox(QGroupBox):
         self.dir_combo = QComboBox()
         self.layout_dir.addWidget(self.dir_combo)
         self.dir_combo.setEditable(True)
-        self.dir_combo.setInsertPolicy(QComboBox.InsertAtTop)
+        self.dir_combo.setInsertPolicy(QComboBox.InsertPolicy.InsertAtTop)
         self.dir_combo.currentIndexChanged.connect(self.dc_index_changed)
         self.dir_combo.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Minimum)
         game_directories = json.loads(get_config_value('game_directories', '[]'))
@@ -166,7 +166,7 @@ class GameDirGroupBox(QGroupBox):
         self.sess_combo = QComboBox()
         self.layout_sess.addWidget(self.sess_combo)
         self.sess_combo.setEditable(True)
-        self.sess_combo.setInsertPolicy(QComboBox.InsertAtTop)
+        self.sess_combo.setInsertPolicy(QComboBox.InsertPolicy.InsertAtTop)
         self.sess_combo.currentIndexChanged.connect(self.sess_index_changed)
         self.sess_combo.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Minimum)
         session_directories = json.loads(get_config_value('session_directories', '[]'))
@@ -214,7 +214,7 @@ class GameDirGroupBox(QGroupBox):
         self.saves_value_edit = saves_value_edit
 
         saves_warning_label = QLabel()
-        icon = QApplication.style().standardIcon(QStyle.SP_MessageBoxWarning)
+        icon = QApplication.style().standardIcon(QStyle.StandardPixmap.SP_MessageBoxWarning)
         saves_warning_label.setPixmap(icon.pixmap(16, 16))
         saves_warning_label.hide()
         layout.addWidget(saves_warning_label, 4, 2)
@@ -263,11 +263,11 @@ class GameDirGroupBox(QGroupBox):
     def set_dir_state_icon(self, state):
         style = QApplication.style()
         if state == 'critical':
-            icon = style.standardIcon(QStyle.SP_MessageBoxCritical).pixmap(16, 16)
+            icon = style.standardIcon(QStyle.StandardPixmap.SP_MessageBoxCritical).pixmap(16, 16)
         elif state == 'warning':
-            icon = style.standardIcon(QStyle.SP_MessageBoxWarning).pixmap(16, 16)
+            icon = style.standardIcon(QStyle.StandardPixmap.SP_MessageBoxWarning).pixmap(16, 16)
         elif state == 'ok':
-            icon = style.standardIcon(QStyle.SP_DialogApplyButton).pixmap(16, 16)
+            icon = style.standardIcon(QStyle.StandardPixmap.SP_DialogApplyButton).pixmap(16, 16)
         elif state == 'hide':
             self.dir_state_icon.hide()
             return
@@ -496,8 +496,8 @@ antivirus whitelist or select the action to trust this binary when detected.</p>
     error=html.escape(e.strerror))
 
             error_msgbox.setText(text)
-            error_msgbox.addButton(_('OK'), QMessageBox.YesRole)
-            error_msgbox.setIcon(QMessageBox.Critical)
+            error_msgbox.addButton(_('OK'), QMessageBox.ButtonRole.YesRole)
+            error_msgbox.setIcon(QMessageBox.Icon.Critical)
 
             error_msgbox.exec()
             return
@@ -632,7 +632,7 @@ antivirus whitelist or select the action to trust this binary when detected.</p>
         backups_tab.clear_backups()
 
     def set_game_directory(self):
-        options = QFileDialog.DontResolveSymlinks | QFileDialog.ShowDirsOnly
+        options = QFileDialog.Option.DontResolveSymlinks | QFileDialog.Option.ShowDirsOnly
         directory = QFileDialog.getExistingDirectory(self,
                 _('Game directory'), self.dir_combo.currentText(),
                 options=options)
@@ -640,7 +640,7 @@ antivirus whitelist or select the action to trust this binary when detected.</p>
             self.set_dir_combo_value(clean_qt_path(directory))
 
     def set_session_directory(self):
-        options = QFileDialog.DontResolveSymlinks | QFileDialog.ShowDirsOnly
+        options = QFileDialog.Option.DontResolveSymlinks | QFileDialog.Option.ShowDirsOnly
         directory = QFileDialog.getExistingDirectory(self,
                 _('Session directory'), self.sess_combo.currentText(),
                 options=options)
@@ -1328,7 +1328,7 @@ class UpdateGroupBox(QGroupBox):
         self.builds_combo = builds_combo
 
         refresh_warning_label = QLabel()
-        icon = QApplication.style().standardIcon(QStyle.SP_MessageBoxWarning)
+        icon = QApplication.style().standardIcon(QStyle.StandardPixmap.SP_MessageBoxWarning)
         refresh_warning_label.setPixmap(icon.pixmap(16, 16))
         refresh_warning_label.hide()
         layout.addWidget(refresh_warning_label, layout_row, 3)
@@ -1353,7 +1353,7 @@ class UpdateGroupBox(QGroupBox):
         self.find_build_value = find_build_value
 
         find_build_warning_label = QLabel()
-        icon = QApplication.style().standardIcon(QStyle.SP_MessageBoxWarning)
+        icon = QApplication.style().standardIcon(QStyle.StandardPixmap.SP_MessageBoxWarning)
         find_build_warning_label.setPixmap(icon.pixmap(16, 16))
         find_build_warning_label.hide()
         layout.addWidget(find_build_warning_label, layout_row, 3)
@@ -1655,10 +1655,10 @@ class UpdateGroupBox(QGroupBox):
                         'subdirectory to proceed?'))
                     new_subdirectory_msgbox.addButton(_('Create the {name} subdirectory and '
                         'proceed').format(name=subdir_name),
-                        QMessageBox.YesRole)
+                        QMessageBox.ButtonRole.YesRole)
                     new_subdirectory_msgbox.addButton(_('I will choose or create a different '
-                        'directory'), QMessageBox.NoRole)
-                    new_subdirectory_msgbox.setIcon(QMessageBox.Question)
+                        'directory'), QMessageBox.ButtonRole.NoRole)
+                    new_subdirectory_msgbox.setIcon(QMessageBox.Icon.Question)
 
                     if new_subdirectory_msgbox.exec() == 1:
                         return
@@ -1838,10 +1838,10 @@ class UpdateGroupBox(QGroupBox):
             confirm_msgbox.setInformativeText(_('Are you sure you want to '
                 'update your game?'))
             confirm_msgbox.addButton(_('Update the game again'),
-                QMessageBox.YesRole)
+                QMessageBox.ButtonRole.YesRole)
             confirm_msgbox.addButton(_('I do not need to update the '
-                'game again'), QMessageBox.NoRole)
-            confirm_msgbox.setIcon(QMessageBox.Question)
+                'game again'), QMessageBox.ButtonRole.NoRole)
+            confirm_msgbox.setIcon(QMessageBox.Icon.Question)
 
             if confirm_msgbox.exec() == 1:
                 self.updating = False
@@ -2390,8 +2390,8 @@ class UpdateGroupBox(QGroupBox):
                         ).format(error=html.escape(e.strerror))
 
                     error_msgbox.setText(text)
-                    error_msgbox.addButton(_('OK'), QMessageBox.YesRole)
-                    error_msgbox.setIcon(QMessageBox.Critical)
+                    error_msgbox.addButton(_('OK'), QMessageBox.ButtonRole.YesRole)
+                    error_msgbox.setIcon(QMessageBox.Icon.Critical)
 
                     error_msgbox.exec()
 
@@ -3379,7 +3379,7 @@ class UpdateGroupBox(QGroupBox):
             try:
                 new_body = entry['body'].split('####')
             except:
-                print("Can't parse body")
+                print(f"Can't parse body: {entry['html_url']}")
 
             new_date = entry['closed_at'][0:10]
             new_entry = changelog_entry(title =entry['title'],
@@ -3580,10 +3580,10 @@ that file or directory. You might need to end it if you want to retry.</p>'''
                                 'retry removing this directory?'))
                             retry_msgbox.addButton(
                                 _('Retry removing the directory'),
-                                QMessageBox.YesRole)
+                                QMessageBox.ButtonRole.YesRole)
                             retry_msgbox.addButton(_('Cancel the operation'),
-                                QMessageBox.NoRole)
-                            retry_msgbox.setIcon(QMessageBox.Critical)
+                                QMessageBox.ButtonRole.NoRole)
+                            retry_msgbox.setIcon(QMessageBox.Icon.Critical)
 
                             if retry_msgbox.exec() == 1:
                                 self.deleting = False
@@ -3642,10 +3642,10 @@ that file or directory. You might need to end it if you want to retry.</p>'''
                             'retry removing this directory?'))
                         retry_msgbox.addButton(
                             _('Retry removing the directory'),
-                            QMessageBox.YesRole)
+                            QMessageBox.ButtonRole.YesRole)
                         retry_msgbox.addButton(_('Cancel the operation'),
-                            QMessageBox.NoRole)
-                        retry_msgbox.setIcon(QMessageBox.Critical)
+                            QMessageBox.ButtonRole.NoRole)
+                        retry_msgbox.setIcon(QMessageBox.Icon.Critical)
 
                         if retry_msgbox.exec() == 1:
                             self.deleting = False

--- a/cddagl/ui/views/main.py
+++ b/cddagl/ui/views/main.py
@@ -35,7 +35,7 @@ from babel.dates import format_datetime
 from pywintypes import error as PyWinError
 
 import cddagl.constants as cons
-from cddagl.constants import get_cddagl_path, get_cdda_uld_path
+from cddagl.constants import get_cddagl_path
 from cddagl import __version__ as version
 from cddagl.functions import (
     tryint, move_path, sizeof_fmt, delete_path,

--- a/cddagl/ui/views/settings.py
+++ b/cddagl/ui/views/settings.py
@@ -90,7 +90,7 @@ class LauncherSettingsGroupBox(QGroupBox):
         current_locale = get_config_value('locale', None)
 
         locale_combo = QComboBox()
-        locale_combo.setSizeAdjustPolicy(QComboBox.AdjustToContents)
+        locale_combo.setSizeAdjustPolicy(QComboBox.SizeAdjustPolicy.AdjustToContents)
         locale_combo.addItem(_('System language or best match ({locale})'
             ).format(locale=get_ui_locale()), None)
         selected_index = 0
@@ -414,7 +414,7 @@ class UpdateSettingsGroupBox(QGroupBox):
         set_config_value('keep_archive_copy', str(state != Qt.CheckState.Unchecked))
 
     def set_ka_directory(self):
-        options = QFileDialog.DontResolveSymlinks | QFileDialog.ShowDirsOnly
+        options = QFileDialog.Option.DontResolveSymlinks | QFileDialog.Option.ShowDirsOnly
         directory = QFileDialog.getExistingDirectory(self,
                 _('Archive directory'), self.keep_archive_directory_line.text(),
                 options=options)

--- a/cddagl/ui/views/settings.py
+++ b/cddagl/ui/views/settings.py
@@ -214,13 +214,13 @@ class LauncherSettingsGroupBox(QGroupBox):
 
     def nlvcc_changed(self, state):
         set_config_value('prevent_version_check_launch',
-            str(state != Qt.CheckState.Unchecked))
+            str(state != Qt.CheckState.Unchecked.value))
 
     def rsc_changed(self, state):
-        set_config_value('reverse_sort_changelog', str(state != Qt.CheckState.Unchecked))
+        set_config_value('reverse_sort_changelog', str(state != Qt.CheckState.Unchecked.value))
 
     def klo_changed(self, state):
-        checked = state != Qt.CheckState.Unchecked
+        checked = state != Qt.CheckState.Unchecked.value
 
         set_config_value('keep_launcher_open', str(checked))
 
@@ -239,7 +239,7 @@ class LauncherSettingsGroupBox(QGroupBox):
             self.command_line_parameters_edit.text())
 
     def ami_changed(self, state):
-        checked = state != Qt.CheckState.Unchecked
+        checked = state != Qt.CheckState.Unchecked.value
         set_config_value('allow_multiple_instances', str(checked))
 
     def disable_controls(self):
@@ -385,18 +385,18 @@ class UpdateSettingsGroupBox(QGroupBox):
         self.arb_timer.setInterval(value * 1000 * 60)
 
     def arbc_changed(self, state):
-        set_config_value('auto_refresh_builds', str(state != Qt.CheckState.Unchecked))
-        if state != Qt.CheckState.Unchecked:
+        set_config_value('auto_refresh_builds', str(state != Qt.CheckState.Unchecked.value))
+        if state != Qt.CheckState.Unchecked.value:
             self.arb_timer.start()
         else:
             self.arb_timer.stop()
 
     def psmc_changed(self, state):
-        set_config_value('prevent_save_move', str(state != Qt.CheckState.Unchecked))
+        set_config_value('prevent_save_move', str(state != Qt.CheckState.Unchecked.value))
         game_dir_group_box = self.get_main_tab().game_dir_group_box
         saves_warning_label = game_dir_group_box.saves_warning_label
 
-        if state != Qt.CheckState.Unchecked:
+        if state != Qt.CheckState.Unchecked.value:
             saves_warning_label.hide()
         else:
             if game_dir_group_box.saves_size > cons.SAVES_WARNING_SIZE:
@@ -405,13 +405,13 @@ class UpdateSettingsGroupBox(QGroupBox):
                 saves_warning_label.hide()
 
     def rpvc_changed(self, state):
-        set_config_value('remove_previous_version', str(state != Qt.CheckState.Unchecked))
+        set_config_value('remove_previous_version', str(state != Qt.CheckState.Unchecked.value))
 
     def prfc_changed(self, state):
-        set_config_value('permanently_delete_files', str(state != Qt.CheckState.Unchecked))
+        set_config_value('permanently_delete_files', str(state != Qt.CheckState.Unchecked.value))
 
     def kacc_changed(self, state):
-        set_config_value('keep_archive_copy', str(state != Qt.CheckState.Unchecked))
+        set_config_value('keep_archive_copy', str(state != Qt.CheckState.Unchecked.value))
 
     def set_ka_directory(self):
         options = QFileDialog.Option.DontResolveSymlinks | QFileDialog.Option.ShowDirsOnly

--- a/cddagl/ui/views/settings.py
+++ b/cddagl/ui/views/settings.py
@@ -9,7 +9,7 @@ from PySide6.QtWidgets import (
 from babel.core import Locale
 
 import cddagl.constants as cons
-from cddagl.constants import get_locale_path, get_cdda_uld_path
+from cddagl.constants import get_locale_path
 from cddagl.functions import clean_qt_path
 from cddagl.i18n import load_gettext_locale, get_available_locales, proxy_gettext as _
 from cddagl.sql.functions import get_config_value, set_config_value, config_true

--- a/cddagl/ui/views/soundpacks.py
+++ b/cddagl/ui/views/soundpacks.py
@@ -75,7 +75,7 @@ class SoundpacksTab(QTabWidget):
 
         installed_lv = QListView()
         installed_lv.clicked.connect(self.installed_clicked)
-        installed_lv.setEditTriggers(QAbstractItemView.NoEditTriggers)
+        installed_lv.setEditTriggers(QAbstractItemView.EditTrigger.NoEditTriggers)
         installed_gb_layout.addWidget(installed_lv)
         self.installed_lv = installed_lv
 
@@ -109,7 +109,7 @@ class SoundpacksTab(QTabWidget):
 
         repository_lv = QListView()
         repository_lv.clicked.connect(self.repository_clicked)
-        repository_lv.setEditTriggers(QAbstractItemView.NoEditTriggers)
+        repository_lv.setEditTriggers(QAbstractItemView.EditTrigger.NoEditTriggers)
         repository_gb_layout.addWidget(repository_lv)
         self.repository_lv = repository_lv
 
@@ -178,7 +178,7 @@ class SoundpacksTab(QTabWidget):
         homepage_tb.setReadOnly(True)
         homepage_tb.setOpenExternalLinks(True)
         homepage_tb.setMaximumHeight(23)
-        homepage_tb.setLineWrapMode(QTextEdit.NoWrap)
+        homepage_tb.setLineWrapMode(QTextEdit.LineWrapMode.NoWrap)
         homepage_tb.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
         details_gb_layout.addWidget(homepage_tb, 4, 1)
         self.homepage_tb = homepage_tb
@@ -327,10 +327,10 @@ class SoundpacksTab(QTabWidget):
                         'to install the {view} soundpack?').format(
                             view=selected_info['viewname']))
                     confirm_msgbox.addButton(_('Install the soundpack'),
-                        QMessageBox.YesRole)
+                        QMessageBox.ButtonRole.YesRole)
                     confirm_msgbox.addButton(_('Do not install again'),
-                        QMessageBox.NoRole)
-                    confirm_msgbox.setIcon(QMessageBox.Warning)
+                        QMessageBox.ButtonRole.NoRole)
+                    confirm_msgbox.setIcon(QMessageBox.Icon.Warning)
 
                     if confirm_msgbox.exec() == 1:
                         return
@@ -903,15 +903,12 @@ class SoundpacksTab(QTabWidget):
 
         confirm_msgbox = QMessageBox()
         confirm_msgbox.setWindowTitle(_('Delete soundpack'))
-        confirm_msgbox.setText(_('This will delete the soundpack directory. It '
-            'cannot be undone.'))
+        confirm_msgbox.setText(_('This will delete the soundpack directory. It cannot be undone.'))
         confirm_msgbox.setInformativeText(_('Are you sure you want to '
             'delete the {view} soundpack?').format(view=selected_info['VIEW']))
-        confirm_msgbox.addButton(_('Delete the soundpack'),
-            QMessageBox.YesRole)
-        confirm_msgbox.addButton(_('I want to keep the soundpack'),
-            QMessageBox.NoRole)
-        confirm_msgbox.setIcon(QMessageBox.Warning)
+        confirm_msgbox.addButton(_('Delete the soundpack'), QMessageBox.ButtonRole.YesRole)
+        confirm_msgbox.addButton(_('I want to keep the soundpack'), QMessageBox.ButtonRole.NoRole)
+        confirm_msgbox.setIcon(QMessageBox.Icon.Warning)
 
         if confirm_msgbox.exec() == 0:
             main_window = self.get_main_window()

--- a/cddagl/ui/views/tabbed.py
+++ b/cddagl/ui/views/tabbed.py
@@ -301,12 +301,12 @@ class TabbedWindow(QMainWindow):
                 version=version))
             launcher_update_msgbox.setInformativeText(release_html)
             launcher_update_msgbox.addButton(_('Update the launcher'),
-                QMessageBox.YesRole)
+                QMessageBox.ButtonRole.YesRole)
             launcher_update_msgbox.addButton(_('Not right now'),
-                QMessageBox.NoRole)
+                QMessageBox.ButtonRole.NoRole)
             launcher_update_msgbox.setCheckBox(
                 no_launcher_version_check_checkbox)
-            launcher_update_msgbox.setIcon(QMessageBox.Question)
+            launcher_update_msgbox.setIcon(QMessageBox.Icon.Question)
 
             if launcher_update_msgbox.exec() == 0:
                 flags = Qt.WindowType.WindowTitleHint | Qt.WindowType.WindowCloseButtonHint
@@ -336,7 +336,7 @@ class TabbedWindow(QMainWindow):
             up_to_date_msgbox.setWindowTitle(_('Up to date'))
             up_to_date_msgbox.setText(_('The Kitten CDDA Launcher is up to date.'
                 ))
-            up_to_date_msgbox.setIcon(QMessageBox.Information)
+            up_to_date_msgbox.setIcon(QMessageBox.Icon.Information)
 
             up_to_date_msgbox.exec()
 


### PR DESCRIPTION
Fixes #102 

- Fix some more enums that were not properly explicited
- Remove one unused function (unrelated to the issue)
- Improve Thread handling to fix the crash
- Check the actual value of Checked/Unchecked enum to fix settings not loading properly

Test:
- Make two saves
- Set launcher to back up on game start
- Repeatedly start the game:  before changes >crash | After changes > no crash
- Repeatedly backup the save > no crash
- Change settings, close, reopen, settings are correctly set