### PR TITLE
Cache the list of stable tags

### DIFF
--- a/cddagl/sql/functions.py
+++ b/cddagl/sql/functions.py
@@ -46,8 +46,7 @@ def init_config(basedir):
         os.remove(get_config_path())
         command.upgrade(alembic_cfg, "head")
 
-
-def get_config_path():
+def get_config_dir():
     local_app_data = os.environ.get('LOCALAPPDATA', os.environ.get('APPDATA'))
     if local_app_data is None or not os.path.isdir(local_app_data):
         local_app_data = ''
@@ -57,6 +56,10 @@ def get_config_path():
     if not os.path.isdir(config_dir):
         os.makedirs(config_dir)
 
+    return config_dir
+
+def get_config_path():
+    config_dir = get_config_dir()
     return os.path.join(config_dir, 'configs.db')
 
 


### PR DESCRIPTION
Sorting through all existing release tags to find stable and stable candidates force us to download, parse and sort a 11457 entry json dictionary and we're doing every time the stable release tab opens, that's a bit much

Instead this change make it so we cache the [ETag](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/ETag), and the short list of tags we interested in, and we use [If-None-Match header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/If-None-Match) in our request passing the ETag is we already have it. That way we only redownload, parse and sort through that list if it has changed since last visit
