### PR TITLE
Fix stable fetching again

### DIFF
--- a/cddagl/ui/views/main.py
+++ b/cddagl/ui/views/main.py
@@ -2936,7 +2936,7 @@ class UpdateGroupBox(QGroupBox):
         # Init vars
         status_bar = self.get_main_window().statusBar()
         url = cons.GITHUB_REST_API_URL + cons.CDDA_RELEASE_TAGS
-        tag_regex = re.compile(r'(refs/tags/)(cdda-|)(0\.[A-Z]-)([0-9\-]+|[a-zA-Z]+|)')
+        tag_regex = re.compile(r'(refs/tags/)(cdda-|)(0\.[A-Z])(-[0-9\-]+|[a-zA-Z]+|)')
         stable_tags = []
 
         # Make request for the tags


### PR DESCRIPTION
Regex for stable tags did not account for the tag being only `0.<letter>` even though that's what it was supposed to be everytime

This should fix it

When it breaks again next year with the new stable I should look into using `prerelease: False` as the criteria for stable instead of the release tag